### PR TITLE
fix: prevent pixels from escaping screen bounds

### DIFF
--- a/src/systems/material-movement/MaterialMovementSystem.ts
+++ b/src/systems/material-movement/MaterialMovementSystem.ts
@@ -63,7 +63,7 @@ export abstract class MaterialMovementSystem {
       this.isPointInsideCanvasWidthGrid(gridPos, ctx)
     ) {
       ctx.grid.delete(`${gridPos.x},${gridPos.y}`)
-      ctx.grid.set(`${side},${gridPos.y}`, entity)
+      ctx.grid.set(side, entity)
       const offset = material.currentDirection === DIRECTION.RIGHT ? 1 : -1
 
       this.updateEntityPositionFromGridPos(
@@ -86,20 +86,26 @@ export abstract class MaterialMovementSystem {
 
     const leftPosition = gridPos.x - 1
     const rightPosition = gridPos.x + 1
-    const diagonalLeftKey = `${leftPosition},${gridPos.y + ctx.fallSpeed}`
+    const nextY = gridPos.y + ctx.fallSpeed
 
-    const newPosition = !ctx.grid.has(diagonalLeftKey)
-      ? leftPosition
-      : rightPosition
+    const diagonalLeftKey = `${leftPosition},${nextY}`
+    const diagonalRightKey = `${rightPosition},${nextY}`
+
+    const leftFree = leftPosition >= 0 && !ctx.grid.has(diagonalLeftKey)
+    const rightFree = rightPosition <= ctx.canvasGridWidth && !ctx.grid.has(diagonalRightKey)
+
+    if (!leftFree && !rightFree) return
+
+    const newPosition = leftFree ? leftPosition : rightPosition
 
     ctx.grid.delete(`${gridPos.x},${gridPos.y}`)
-    ctx.grid.set(`${newPosition},${gridPos.y + ctx.fallSpeed}`, entity)
+    ctx.grid.set(`${newPosition},${nextY}`, entity)
 
     this.updateEntityPositionFromGridPos(
       pos,
       PointUtils.getCanvasCoord({
         x: newPosition,
-        y: gridPos.y + ctx.fallSpeed
+        y: nextY
       })
     )
   }
@@ -109,12 +115,6 @@ export abstract class MaterialMovementSystem {
     ctx: MaterialMovementContext
   ): boolean {
     return gridPos.y + ctx.fallSpeed > ctx.canvasGridHeight
-  }
-
-  // TODO Z jakiegoś powodu niektóre pixele uciekają poza ekran
-  protected isInsideCanvasWidth(xPos: number, ctx: MaterialMovementContext) {
-    console.log({ pos: xPos, ctx: ctx.canvasGridWidth })
-    return xPos >= 0 && xPos <= ctx.canvasGridWidth
   }
 
   private updateEntityPositionFromGridPos(

--- a/src/systems/material-movement/material-type/LiquidMaterialSystem.ts
+++ b/src/systems/material-movement/material-type/LiquidMaterialSystem.ts
@@ -23,13 +23,14 @@ export class LiquidMaterialSystem extends MaterialMovementSystem {
 
     const leftPosition = gridPos.x - 1
     const rightPosition = gridPos.x + 1
-    const diagonalLeftKey = `${leftPosition},${gridPos.y + ctx.fallSpeed}`
-    const diagonalRightKey = `${rightPosition},${gridPos.y + ctx.fallSpeed}`
+    const nextY = gridPos.y + ctx.fallSpeed
+    const diagonalLeftKey = `${leftPosition},${nextY}`
+    const diagonalRightKey = `${rightPosition},${nextY}`
 
-    if (
-      (ctx.grid.has(positionBelow) && !ctx.grid.has(diagonalLeftKey)) ||
-      !ctx.grid.has(diagonalRightKey)
-    ) {
+    const leftFree = leftPosition >= 0 && !ctx.grid.has(diagonalLeftKey)
+    const rightFree = rightPosition <= ctx.canvasGridWidth && !ctx.grid.has(diagonalRightKey)
+
+    if (leftFree || rightFree) {
       this.moveDiagonal(entity, ctx)
       return
     }

--- a/src/systems/material-movement/material-type/LooseMaterialSystem.ts
+++ b/src/systems/material-movement/material-type/LooseMaterialSystem.ts
@@ -26,13 +26,14 @@ export class LooseMaterialSystem extends MaterialMovementSystem {
 
     const leftPosition = gridPos.x - 1
     const rightPosition = gridPos.x + 1
-    const diagonalLeftKey = `${leftPosition},${gridPos.y + ctx.fallSpeed}`
-    const diagonalRightKey = `${rightPosition},${gridPos.y + ctx.fallSpeed}`
+    const nextY = gridPos.y + ctx.fallSpeed
+    const diagonalLeftKey = `${leftPosition},${nextY}`
+    const diagonalRightKey = `${rightPosition},${nextY}`
 
-    if (
-      ctx.grid.has(positionBelow) &&
-      (!ctx.grid.has(diagonalLeftKey) || !ctx.grid.has(diagonalRightKey))
-    ) {
+    const leftFree = leftPosition >= 0 && !ctx.grid.has(diagonalLeftKey)
+    const rightFree = rightPosition <= ctx.canvasGridWidth && !ctx.grid.has(diagonalRightKey)
+
+    if (ctx.grid.has(positionBelow) && (leftFree || rightFree)) {
       this.moveDiagonal(entity, ctx)
       return
     }


### PR DESCRIPTION
## Summary

- **moveDiagonal**: pixel at canvas edge with occupied left diagonal moved to canvasGridWidth+1 (off screen). Added bounds check.
- **moveOnSide**: wrong grid key "x,y,y" instead of "x,y" making entity invisible in grid after move.
- **LiquidMaterialSystem / LooseMaterialSystem**: diagonal condition ignored screen bounds. Replaced with leftFree/rightFree flags.
- **LooseMaterialSystem**: sleeping=true never set when both diagonals OOB.
- Removed unused isInsideCanvasWidth with console.log.

## Test plan
- [ ] Sand/water at screen edges do not escape
- [ ] No console.log spam in browser console

Generated with Claude Code